### PR TITLE
[Utils] Add safe run logging

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+mypy_path = src
+explicit_package_bases = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,6 @@ testpaths =
 python_files = test_*.py
 python_functions = test_*
 cache_dir = .pytest_cache
+markers =
+    unit: Unit Tests
+    integration: Integration Tests

--- a/src/utils/safe_run.py
+++ b/src/utils/safe_run.py
@@ -1,6 +1,8 @@
 from functools import wraps
 from time import sleep
 
+from utils.main_logger import MainLogger
+
 
 def safe_run(retries: int = 3, delay: int = 10):
     """Decorator factory that adds try/except and retry functionality to a function.
@@ -28,13 +30,13 @@ def safe_run(retries: int = 3, delay: int = 10):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
+            logger = MainLogger().get_logger()
             for retry in range(1, retries + 1):  # Iterate through each retry attempt
                 try:
                     return func(*args, **kwargs)
                 except Exception as e:
-                    # TODO: SWITCH TO LOGGER
-                    print(f"This function has failed with the error: {e}")
-                    print(f"This is attempt number {retry}")
+                    logger.error(f"This function has failed with the error: {e}")
+                    logger.info(f"This is attempt number {retry}")
                     if (
                         retry == retries
                     ):  # If the maximum number of retries has been reached

--- a/tests/integration/test_main_logger_integration.py
+++ b/tests/integration/test_main_logger_integration.py
@@ -1,0 +1,39 @@
+import logging
+import pytest
+from utils.safe_run import safe_run
+
+attempt_tracker = {"count": 0}
+
+@safe_run()
+def fails_once():
+    """Returns True if the counter is not zero, otherwise it increments counter and raises Exception
+
+    Returns:
+        True (bool)
+
+    Raises:
+        Exception: An exception is always raised
+    """
+    if attempt_tracker["count"] == 0:
+        attempt_tracker["count"] += 1
+        raise Exception("An exception has been raised")
+    return True
+
+def test_logs_output_in_safe_run(caplog):
+    """Tests that the logger outputs the expected logs in the safe_run function.
+
+    Given:
+        - A failing function
+        - The safe_run decorator factory wrapped around the failing function
+
+    When:
+        - Calling the failing function
+
+    Then:
+        - The logger should output the expected logs in the safe_run function
+    """
+    caplog.set_level(logging.INFO)
+    fails_once()
+
+    assert "This function has failed with the error:" in caplog.text
+    assert "This is attempt number" in caplog.text

--- a/tests/integration/test_main_logger_integration.py
+++ b/tests/integration/test_main_logger_integration.py
@@ -19,6 +19,7 @@ def fails_once():
         raise Exception("An exception has been raised")
     return True
 
+@pytest.mark.integration
 def test_logs_output_in_safe_run(caplog):
     """Tests that the logger outputs the expected logs in the safe_run function.
 

--- a/tests/unit/utils/test_main_logger_unit.py
+++ b/tests/unit/utils/test_main_logger_unit.py
@@ -112,23 +112,6 @@ def test_logger_name(setup):
     assert logger.name == expected_logger_name
 
 
-def test_num_handlers(setup):
-    """Tests that MainLogger is initialised with the correct number of handlers.
-
-    Given:
-        - An instance of the MainLogger via the fixture
-
-    When:
-        - Calling get_logger() on the instance
-
-    Then:
-        - The logger should have the expected number of handlers
-    """
-    expected_num_handlers = 5
-    logger = setup.get_logger()
-    assert len(logger.handlers) == expected_num_handlers
-
-
 """
 Output logs
 """

--- a/tests/unit/utils/test_main_logger_unit.py
+++ b/tests/unit/utils/test_main_logger_unit.py
@@ -23,7 +23,7 @@ def setup():
 __new__()
 """
 
-
+@pytest.mark.unit
 def test_initialise_is_called():
     """Tests that _initialise() is called once upon the first time the MainLogger is called.
 
@@ -40,7 +40,7 @@ def test_initialise_is_called():
         _ = MainLogger()
         mock_initialise.assert_called_once()
 
-
+@pytest.mark.unit
 def test_initialise_is_not_called_second_time(setup):
     """Tests that _initialise() is not called upon the second time the MainLogger is called.
 
@@ -72,7 +72,7 @@ def test_instance_exists(setup):
     """
     assert setup._instance is not None
 
-
+@pytest.mark.unit
 def test_call_second_instance(setup):
     """Tests that _instance exists upon the second time the MainLogger is called.
 
@@ -93,7 +93,7 @@ def test_call_second_instance(setup):
 _initialise()
 """
 
-
+@pytest.mark.unit
 def test_logger_name(setup):
     """Tests that MainLogger is initialised with the correct name.
 
@@ -116,7 +116,7 @@ def test_logger_name(setup):
 Output logs
 """
 
-
+@pytest.mark.unit
 def test_debug_logs_does_not_output(caplog, setup):
     """Tests that the logger does not output any debug level logs.
 
@@ -136,7 +136,7 @@ def test_debug_logs_does_not_output(caplog, setup):
 
     assert "test debug" not in caplog.text
 
-
+@pytest.mark.unit
 def test_info_logs(caplog, setup):
     """Tests that the logger outputs info level logs.
 
@@ -157,7 +157,7 @@ def test_info_logs(caplog, setup):
     assert "test info" in caplog.text
     assert "INFO" in caplog.text
 
-
+@pytest.mark.unit
 def test_warning_logs(caplog, setup):
     """Tests that the logger outputs warning level logs.
 
@@ -178,7 +178,7 @@ def test_warning_logs(caplog, setup):
     assert "test warning" in caplog.text
     assert "WARNING" in caplog.text
 
-
+@pytest.mark.unit
 def test_error_logs(caplog, setup):
     """Tests that the logger outputs error level logs.
 
@@ -199,7 +199,7 @@ def test_error_logs(caplog, setup):
     assert "test error" in caplog.text
     assert "ERROR" in caplog.text
 
-
+@pytest.mark.unit
 def test_critical_logs(caplog, setup):
     """Tests that the logger outputs critical level logs.
 

--- a/tests/unit/utils/test_safe_run.py
+++ b/tests/unit/utils/test_safe_run.py
@@ -190,17 +190,17 @@ def test_safe_run_fails_once():
 """The following tests have the same test plan as the first half but have the safe_run parameters updated"""
 
 
-@safe_run(5, 5)
+@safe_run(5, 1)
 def success_func_updated():
     return True
 
 
-@safe_run(5, 5)
+@safe_run(5, 1)
 def failing_func_updated():
     raise Exception("An exception has been raised")
 
 
-@safe_run(5, 5)
+@safe_run(5, 1)
 def fails_once_updated():
     if attempt_tracker["count"] == 0:
         attempt_tracker["count"] += 1

--- a/tests/unit/utils/test_safe_run.py
+++ b/tests/unit/utils/test_safe_run.py
@@ -1,27 +1,6 @@
 import pytest
 from utils.safe_run import safe_run
 
-"""
-Define a function to be decorated
-
-Incorrect parameters:
-1) retries is less than or equal to 0
-2) delay is less than or equal to 0
-3) retries is an incorrect format
-4) delay is an incorrect format
-
-Without changing parameters:
-1) Succeeds
-2) Fails once then succeeds
-3) Fails everytime
-
-With changing parameters
-1) Succeeds
-2) Fails once then succeeds
-3) Fails everytime
-"""
-
-
 def dummy():
     """Dummy function that always returns True
 


### PR DESCRIPTION
### Summary
Add logging from MainLogger() to the safe_run decorator factory
### Changes
* Added logging for safe_run upon each Exception
* Added Pytest markers to separate unit and integration tests
### Test Plan
* Used caplog to capture log output
* Implemented an integration test to evaluate the log output for the subsystem
### Evidence
* ============1 passed, 20 deselected in 10.05s ============
### Additional Notes
* https://docs.pytest.org/en/stable/example/markers.html