### PR TITLE
[Ingest Market Data] Convert Pandas DF into Spark DF

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ cache_dir = .pytest_cache
 markers =
     unit: Unit Tests
     integration: Integration Tests
+    spark_df_success: Spark Success DF

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,3 @@ yfinance
 ruff
 mypy
 pytest-mock
-git checkout your-branch
-git fetch origin
-git merge -X ours origin/main  # 'ours' means: keep my version

--- a/src/infrastructure/spark/spark_session_manager.py
+++ b/src/infrastructure/spark/spark_session_manager.py
@@ -8,9 +8,10 @@ from utils.safe_run import safe_run
 
 class SparkSessionManager:
     """Represents the Spark Session Manager
-    
+
     Attributes:
         - spark_session (SparkSession or None): Contains the singleton instance of the SparkSession"""
+
     spark_session = None
 
     def __init__(self, logger):

--- a/src/utils/load_spark_config.py
+++ b/src/utils/load_spark_config.py
@@ -8,9 +8,9 @@ from utils.safe_run import safe_run
 def load_spark_config(path: str = "src/config/spark_config.yaml") -> SparkConf:
     """Loads the Spark configuration using fields from the Spark configuration YAML file
 
-        Args:
-            - path: The file path of the Spark configuration YAML file
-        """
+    Args:
+        - path: The file path of the Spark configuration YAML file
+    """
     with open(path, "r") as file:
         spark_config = yaml.safe_load(file)
 

--- a/src/utils/pandas_into_spark_df.py
+++ b/src/utils/pandas_into_spark_df.py
@@ -1,0 +1,14 @@
+from logging import Logger
+from pyspark.sql import SparkSession
+import pandas as pd
+
+from utils.safe_run import safe_run
+
+
+@safe_run
+def pandas_into_spark_df(
+    spark_session: SparkSession, pandas_df: pd.DataFrame, logger: Logger
+):
+    spark_df = spark_session.createDataFrame(pandas_df)
+    logger.info("The inputted data has been converted into a Spark DataFrame")
+    return spark_df

--- a/src/utils/pandas_into_spark_df.py
+++ b/src/utils/pandas_into_spark_df.py
@@ -9,6 +9,8 @@ from utils.safe_run import safe_run
 def pandas_into_spark_df(
     spark_session: SparkSession, pandas_df: pd.DataFrame, logger: Logger
 ):
+    if not pandas_df:
+        raise TypeError("Pandas DataFrame cannot be None")
     spark_df = spark_session.createDataFrame(pandas_df)
     logger.info("The inputted data has been converted into a Spark DataFrame")
     return spark_df

--- a/src/utils/pandas_into_spark_df.py
+++ b/src/utils/pandas_into_spark_df.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from utils.safe_run import safe_run
 
+
 @safe_run()
 def pandas_into_spark_df(
     spark_session: SparkSession, pandas_df: pd.DataFrame, logger: Logger

--- a/src/utils/pandas_into_spark_df.py
+++ b/src/utils/pandas_into_spark_df.py
@@ -9,8 +9,20 @@ from utils.safe_run import safe_run
 def pandas_into_spark_df(
     spark_session: SparkSession, pandas_df: pd.DataFrame, logger: Logger
 ):
-    if not pandas_df:
-        raise TypeError("Pandas DataFrame cannot be None")
+    """Converts Pandas DataFrame into a Spark DataFrame
+
+    Args:
+        - spark_session (SparkSession): The current Spark session
+        - pandas_df (pd.DataFrame): A Pandas DataFrame of the ingested tick data
+        - logger (Logger): The logger returned from the MainLogger class
+
+    Returns:
+        spark_df (DataFrame): A Spark DataFrame of the ingested tick data
+
+    Raises:
+        TypeError: If the inputted Pandas DataFrame is None"""
+    if pandas_df is None or pandas_df.empty:
+        raise TypeError("Pandas DataFrame cannot be None or empty")
     spark_df = spark_session.createDataFrame(pandas_df)
     logger.info("The inputted data has been converted into a Spark DataFrame")
     return spark_df

--- a/src/utils/pandas_into_spark_df.py
+++ b/src/utils/pandas_into_spark_df.py
@@ -4,8 +4,7 @@ import pandas as pd
 
 from utils.safe_run import safe_run
 
-
-@safe_run
+@safe_run()
 def pandas_into_spark_df(
     spark_session: SparkSession, pandas_df: pd.DataFrame, logger: Logger
 ):

--- a/tests/integration/test_pandas_into_spark_df_integration.py
+++ b/tests/integration/test_pandas_into_spark_df_integration.py
@@ -3,7 +3,6 @@ from infrastructure.spark.spark_session_manager import SparkSessionManager
 from utils.main_logger import MainLogger
 from utils.pandas_into_spark_df import pandas_into_spark_df
 import pandas as pd
-from pyspark.sql.functions import array_contains
 from pyspark.sql import dataframe as sp_df
 
 
@@ -13,11 +12,10 @@ def setup():
     test_logger = main_logger.get_logger()
     spark_session_manager = SparkSessionManager(test_logger)
     spark_session = spark_session_manager.get_spark_session()
-    d = {'Open': [100.0], 'Close': [101.0]}
+    d = {"Open": [100.0], "Close": [101.0]}
     df = pd.DataFrame(data=d)
 
     yield spark_session, df, test_logger
-    
 
 
 @pytest.mark.integration
@@ -29,6 +27,7 @@ def test_pandas_into_spark_df_with_invalid_spark_session(setup):
     with pytest.raises(Exception):
         pandas_into_spark_df(test_spark_session, pandas_df, test_logger)
 
+
 @pytest.mark.integration
 def test_pandas_into_spark_df_with_invalid_pandas_df(setup):
     test_spark_session = setup[0]
@@ -38,6 +37,7 @@ def test_pandas_into_spark_df_with_invalid_pandas_df(setup):
     with pytest.raises(Exception):
         pandas_into_spark_df(test_spark_session, pandas_df, test_logger)
 
+
 @pytest.mark.integration
 def test_pandas_into_spark_df_with_invalid_test_logger(setup):
     test_spark_session = setup[0]
@@ -46,6 +46,7 @@ def test_pandas_into_spark_df_with_invalid_test_logger(setup):
 
     with pytest.raises(Exception):
         pandas_into_spark_df(test_spark_session, pandas_df, test_logger)
+
 
 @pytest.mark.spark_df_success
 def test_pandas_into_spark_df_success(setup):

--- a/tests/integration/test_pandas_into_spark_df_integration.py
+++ b/tests/integration/test_pandas_into_spark_df_integration.py
@@ -48,7 +48,7 @@ def test_pandas_into_spark_df_with_invalid_test_logger(setup):
         pandas_into_spark_df(test_spark_session, pandas_df, test_logger)
 
 
-@pytest.mark.spark_df_success
+@pytest.mark.integration
 def test_pandas_into_spark_df_success(setup):
     test_spark_session = setup[0]
     pandas_df = setup[1]

--- a/tests/integration/test_pandas_into_spark_df_integration.py
+++ b/tests/integration/test_pandas_into_spark_df_integration.py
@@ -106,4 +106,3 @@ def test_pandas_into_spark_df_success(setup):
     assert isinstance(spark_df, sp_df.DataFrame)
     assert "Open" in spark_df.columns
     assert "Close" in spark_df.columns
-

--- a/tests/integration/test_pandas_into_spark_df_integration.py
+++ b/tests/integration/test_pandas_into_spark_df_integration.py
@@ -1,0 +1,70 @@
+import pytest
+from infrastructure.spark.spark_session_manager import SparkSessionManager
+from utils.main_logger import MainLogger
+from utils.pandas_into_spark_df import pandas_into_spark_df
+import pandas as pd
+from pyspark.sql.functions import array_contains
+from pyspark.sql import dataframe as sp_df
+
+
+@pytest.fixture
+def setup():
+    main_logger = MainLogger()
+    test_logger = main_logger.get_logger()
+    spark_session_manager = SparkSessionManager(test_logger)
+    spark_session = spark_session_manager.get_spark_session()
+    d = {'Open': [100.0], 'Close': [101.0]}
+    df = pd.DataFrame(data=d)
+
+    yield spark_session, df, test_logger
+    
+
+
+@pytest.mark.integration
+def test_pandas_into_spark_df_with_invalid_spark_session(setup):
+    test_spark_session = None
+    pandas_df = setup[1]
+    test_logger = setup[2]
+
+    with pytest.raises(Exception):
+        pandas_into_spark_df(test_spark_session, pandas_df, test_logger)
+
+@pytest.mark.integration
+def test_pandas_into_spark_df_with_invalid_pandas_df(setup):
+    test_spark_session = setup[0]
+    pandas_df = None
+    test_logger = setup[2]
+
+    with pytest.raises(Exception):
+        pandas_into_spark_df(test_spark_session, pandas_df, test_logger)
+
+@pytest.mark.integration
+def test_pandas_into_spark_df_with_invalid_test_logger(setup):
+    test_spark_session = setup[0]
+    pandas_df = setup[1]
+    test_logger = None
+
+    with pytest.raises(Exception):
+        pandas_into_spark_df(test_spark_session, pandas_df, test_logger)
+
+@pytest.mark.spark_df_success
+def test_pandas_into_spark_df_success(setup):
+    test_spark_session = setup[0]
+    pandas_df = setup[1]
+    test_logger = setup[2]
+
+    spark_df = pandas_into_spark_df(test_spark_session, pandas_df, test_logger)
+
+    expected_open_value = [100.0]
+    expected_close_value = [101.0]
+
+    print(f"The Spark DataFrame returned is {spark_df}")
+
+    assert isinstance(spark_df, sp_df.DataFrame)
+
+    rows = spark_df.select("Open", "Close").collect()
+    open_vals = [row["Open"] for row in rows]
+    close_vals = [row["Close"] for row in rows]
+
+    assert open_vals == expected_open_value
+    assert close_vals == expected_close_value

--- a/tests/integration/utils/test_load_spark_config_integration.py
+++ b/tests/integration/utils/test_load_spark_config_integration.py
@@ -7,14 +7,14 @@ from utils.load_spark_config import load_spark_config
 @pytest.mark.integration
 def test_load_spark_config_missing_spark_key(tmp_path):
     """Tests loading the Spark configuration with a missing Spark key
-    
+
     Given:
         - A config path using tmp_path
         - YAML content without a Spark key
-        
+
     When:
         - load_spark_config() is called
-        
+
     Then:
         - An Exception is raised"""
     yaml_content = {
@@ -32,14 +32,14 @@ def test_load_spark_config_missing_spark_key(tmp_path):
 @pytest.mark.integration
 def test_load_spark_config_missing_app_name_key(tmp_path):
     """Tests loading the Spark configuration with a missing app_name key
-    
+
     Given:
         - A config path using tmp_path
         - YAML content without an app_name key
-        
+
     When:
         - load_spark_config() is called
-        
+
     Then:
         - An Exception is raised"""
     yaml_content = {
@@ -57,14 +57,14 @@ def test_load_spark_config_missing_app_name_key(tmp_path):
 @pytest.mark.integration
 def test_load_spark_config_missing_master_key(tmp_path):
     """Tests loading the Spark configuration with a missing master key
-    
+
     Given:
         - A config path using tmp_path
         - YAML content without a master key
-        
+
     When:
         - load_spark_config() is called
-        
+
     Then:
         - An Exception is raised"""
     yaml_content = {
@@ -82,13 +82,13 @@ def test_load_spark_config_missing_master_key(tmp_path):
 @pytest.mark.integration
 def test_load_spark_config_file_not_found(tmp_path):
     """Tests loading the Spark configuration with a missing app_name key
-    
+
     Given:
         - An incorrect filepath
-        
+
     When:
         - load_spark_config() is called
-        
+
     Then:
         - An Exception is raised"""
     with pytest.raises(Exception):
@@ -101,10 +101,10 @@ def test_load_spark_config_success(tmp_path):
     Given:
         - A config path using tmp_path
         - YAML content written to the config file
-        
+
     When:
         - load_spark_config() is called
-        
+
     Then:
         - The expected content is returned in a SparkConf object"""
     yaml_content = {"spark": {"app_name": "integration-test-app", "master": "local[*]"}}

--- a/tests/unit/infrastructure/spark/test_spark_session_manager_unit.py
+++ b/tests/unit/infrastructure/spark/test_spark_session_manager_unit.py
@@ -4,6 +4,7 @@ import pytest
 from infrastructure.spark.spark_session_manager import SparkSessionManager
 from utils.main_logger import MainLogger
 
+
 @pytest.fixture
 def setup():
     main_logger = MainLogger()
@@ -11,6 +12,7 @@ def setup():
     spark_session_manager = SparkSessionManager(logger)
     if spark_session_manager.spark_session:
         spark_session_manager.stop_spark_session()
+
 
 @pytest.mark.unit
 def test_get_spark_session(setup, mocker):
@@ -26,8 +28,11 @@ def test_get_spark_session(setup, mocker):
 
     print(f"The current Spark session is {test_manager.spark_session}")
 
-    with patch("infrastructure.spark.spark_session_manager.SparkSession.builder", new=mock_builder):
+    with patch(
+        "infrastructure.spark.spark_session_manager.SparkSession.builder",
+        new=mock_builder,
+    ):
         result_session = test_manager.get_spark_session()
-        # assert result_session == mock_session
+        assert result_session == mock_session
         mock_builder.config.assert_called_once()
         mock_config.getOrCreate.assert_called_once()

--- a/tests/unit/infrastructure/spark/test_spark_session_manager_unit.py
+++ b/tests/unit/infrastructure/spark/test_spark_session_manager_unit.py
@@ -2,10 +2,18 @@ from unittest.mock import patch
 import pytest
 
 from infrastructure.spark.spark_session_manager import SparkSessionManager
+from utils.main_logger import MainLogger
 
+@pytest.fixture
+def setup():
+    main_logger = MainLogger()
+    logger = main_logger.get_logger()
+    spark_session_manager = SparkSessionManager(logger)
+    if spark_session_manager.spark_session:
+        spark_session_manager.stop_spark_session()
 
 @pytest.mark.unit
-def test_get_spark_session(mocker):
+def test_get_spark_session(setup, mocker):
     mock_logger = mocker.Mock()
     mock_session = mocker.Mock()
     mock_builder = mocker.Mock()
@@ -16,8 +24,10 @@ def test_get_spark_session(mocker):
 
     test_manager = SparkSessionManager(logger=mock_logger)
 
-    with patch("pyspark.sql.SparkSession.builder", new=mock_builder):
+    print(f"The current Spark session is {test_manager.spark_session}")
+
+    with patch("infrastructure.spark.spark_session_manager.SparkSession.builder", new=mock_builder):
         result_session = test_manager.get_spark_session()
-        assert result_session == mock_session
+        # assert result_session == mock_session
         mock_builder.config.assert_called_once()
         mock_config.getOrCreate.assert_called_once()

--- a/tests/unit/infrastructure/test_yahoo_finance_api_client_unit.py
+++ b/tests/unit/infrastructure/test_yahoo_finance_api_client_unit.py
@@ -3,7 +3,6 @@ import pytest
 from infrastructure.apis.yahoo_finance_api_client import YFinanceClient
 
 
-
 @pytest.mark.unit
 def test_fetch_market_data_with_invalid_ticker(mocker):
     """Tests that fetch_market_data raises a ValueError with an unavailable ticker inputted.

--- a/tests/unit/test_pandas_into_spark_df_unit.py
+++ b/tests/unit/test_pandas_into_spark_df_unit.py
@@ -86,6 +86,6 @@ def test_pandas_into_spark_df_success(mocker, pandas_df, spark_df):
     mock_spark_session.createDataFrame.return_value = spark_df
 
     result = pandas_into_spark_df(mock_spark_session, pandas_df, mock_logger)
-    
+
     assert isinstance(result, DataFrame)
     assertDataFrameEqual(spark_df, result)

--- a/tests/unit/test_pandas_into_spark_df_unit.py
+++ b/tests/unit/test_pandas_into_spark_df_unit.py
@@ -43,6 +43,27 @@ def test_pandas_into_spark_df_with_invalid_spark_session(mocker, pandas_df):
     with pytest.raises(Exception):
         pandas_into_spark_df(mock_spark_session, pandas_df, mock_logger)
 
+@pytest.mark.spark_df_success
+def test_pandas_into_spark_df_with_invalid_pandas_df(mocker, pandas_df):
+    """Tests that pandas_into_spark_df with an invalid Spark session raises an Exception
+
+    Given:
+        - A test Pandas DataFrame
+        - A mock Spark Session set to None
+        - A mock logger
+
+    When:
+        - pandas_into_spark_df() is called with these parameters
+
+    Then:
+        - An Exception is raised"""
+    mock_spark_session = mocker.Mock()
+    mock_pandas_df = None
+    mock_logger = mocker.Mock()
+
+    with pytest.raises(TypeError):
+        pandas_into_spark_df(mock_spark_session, mock_pandas_df, mock_logger)
+
 
 @pytest.mark.unit
 def test_pandas_into_spark_df_with_invalid_logger(mocker, pandas_df, spark_df):

--- a/tests/unit/test_pandas_into_spark_df_unit.py
+++ b/tests/unit/test_pandas_into_spark_df_unit.py
@@ -1,13 +1,15 @@
 import pandas as pd
 import pytest
-from pyspark.sql import Row
-from pyspark.sql import SparkSession
+from pyspark.sql import Row, SparkSession
+from pyspark.sql.dataframe import DataFrame
+from pyspark.testing.utils import assertDataFrameEqual
 
 from utils.pandas_into_spark_df import pandas_into_spark_df
 
 
 @pytest.fixture
 def pandas_df():
+    """Yields a test Pandas DataFrame of tick data"""
     d = {"Open": [100.0], "Close": [101.0]}
     df = pd.DataFrame(data=d)
     yield df
@@ -15,13 +17,26 @@ def pandas_df():
 
 @pytest.fixture
 def spark_df():
+    """Yields a test Spark DataFrame of tick data"""
     spark = SparkSession.builder.getOrCreate()
     mock_spark_df = spark.createDataFrame([Row(Open=100.0, Close=101.0)])
     yield mock_spark_df
 
 
 @pytest.mark.unit
-def test_pandas_into_spark_df_with_invalid_spark_session(mocker, pandas_df, spark_df):
+def test_pandas_into_spark_df_with_invalid_spark_session(mocker, pandas_df):
+    """Tests that pandas_into_spark_df with an invalid Spark session raises an Exception
+
+    Given:
+        - A test Pandas DataFrame
+        - A mock Spark Session set to None
+        - A mock logger
+
+    When:
+        - pandas_into_spark_df() is called with these parameters
+
+    Then:
+        - An Exception is raised"""
     mock_spark_session = None
     mock_logger = mocker.Mock()
 
@@ -31,6 +46,18 @@ def test_pandas_into_spark_df_with_invalid_spark_session(mocker, pandas_df, spar
 
 @pytest.mark.unit
 def test_pandas_into_spark_df_with_invalid_logger(mocker, pandas_df, spark_df):
+    """Tests that pandas_into_spark_df with an invalid logger raises an Exception
+
+    Given:
+        - A test Pandas DataFrame
+        - A mock Spark Session
+        - A mock logger set to None
+
+    When:
+        - pandas_into_spark_df() is called with these parameters
+
+    Then:
+        - An Exception is raised"""
     mock_spark_session = mocker.Mock()
     mock_logger = None
     mock_spark_session.createDataFrame.return_value = spark_df
@@ -41,10 +68,24 @@ def test_pandas_into_spark_df_with_invalid_logger(mocker, pandas_df, spark_df):
 
 @pytest.mark.unit
 def test_pandas_into_spark_df_success(mocker, pandas_df, spark_df):
+    """Tests that pandas_into_spark_df is successful
+
+    Given:
+        - A test Pandas DataFrame
+        - A test Spark DataFrame
+        - A mock Spark Session
+        - A mock logger set to None
+
+    When:
+        - pandas_into_spark_df() is called with these parameters
+
+    Then:
+        - The resultant DataFrame returned will equal the test Spark DataFrame"""
     mock_spark_session = mocker.Mock()
     mock_logger = mocker.Mock()
     mock_spark_session.createDataFrame.return_value = spark_df
 
     result = pandas_into_spark_df(mock_spark_session, pandas_df, mock_logger)
-
-    assert result == spark_df
+    
+    assert isinstance(result, DataFrame)
+    assertDataFrameEqual(spark_df, result)

--- a/tests/unit/test_pandas_into_spark_df_unit.py
+++ b/tests/unit/test_pandas_into_spark_df_unit.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import pytest
+from pyspark.sql import Row
+from pyspark.sql import SparkSession
+
+from utils.pandas_into_spark_df import pandas_into_spark_df
+
+
+@pytest.fixture
+def pandas_df():
+    d = {"Open": [100.0], "Close": [101.0]}
+    df = pd.DataFrame(data=d)
+    yield df
+
+
+@pytest.fixture
+def spark_df():
+    spark = SparkSession.builder.getOrCreate()
+    mock_spark_df = spark.createDataFrame([Row(Open=100.0, Close=101.0)])
+    yield mock_spark_df
+
+
+@pytest.mark.unit
+def test_pandas_into_spark_df_with_invalid_spark_session(mocker, pandas_df, spark_df):
+    mock_spark_session = None
+    mock_logger = mocker.Mock()
+
+    with pytest.raises(Exception):
+        pandas_into_spark_df(mock_spark_session, pandas_df, mock_logger)
+
+
+@pytest.mark.unit
+def test_pandas_into_spark_df_with_invalid_logger(mocker, pandas_df, spark_df):
+    mock_spark_session = mocker.Mock()
+    mock_logger = None
+    mock_spark_session.createDataFrame.return_value = spark_df
+
+    with pytest.raises(Exception):
+        pandas_into_spark_df(mock_spark_session, pandas_df, mock_logger)
+
+
+@pytest.mark.unit
+def test_pandas_into_spark_df_success(mocker, pandas_df, spark_df):
+    mock_spark_session = mocker.Mock()
+    mock_logger = mocker.Mock()
+    mock_spark_session.createDataFrame.return_value = spark_df
+
+    result = pandas_into_spark_df(mock_spark_session, pandas_df, mock_logger)
+
+    assert result == spark_df

--- a/tests/unit/utils/test_load_spark_config_unit.py
+++ b/tests/unit/utils/test_load_spark_config_unit.py
@@ -8,13 +8,13 @@ from unittest.mock import mock_open, patch
 @pytest.mark.unit
 def test_load_spark_config_missing_spark_key():
     """Tests loading the Spark configuration with a missing Spark key
-    
+
     Given:
         - A mocked Spark config with no Spark key
-        
+
     When:
         - load_spark_config() is called
-        
+
     Then:
         - An Exception is raised"""
     mock_spark_config = {"not_spark": {"app_name": "test-app", "master": "local[*]"}}
@@ -28,13 +28,13 @@ def test_load_spark_config_missing_spark_key():
 @pytest.mark.unit
 def test_load_spark_config_missing_app_name_key():
     """Tests loading the Spark configuration with a missing app_name
-    
+
     Given:
         - A mocked Spark config with no app_name
-        
+
     When:
         - load_spark_config() is called
-        
+
     Then:
         - An Exception is raised"""
     mock_spark_config = {"spark": {"not_app_name": "test-app", "master": "local[*]"}}
@@ -48,13 +48,13 @@ def test_load_spark_config_missing_app_name_key():
 @pytest.mark.unit
 def test_load_spark_config_missing_master_key():
     """Tests loading the Spark configuration with a missing master key
-    
+
     Given:
         - A mocked Spark config with no master key
-        
+
     When:
         - load_spark_config() is called
-        
+
     Then:
         - An Exception is raised"""
     mock_spark_config = {"spark": {"app_name": "test-app", "not_master": "local[*]"}}
@@ -68,13 +68,13 @@ def test_load_spark_config_missing_master_key():
 @pytest.mark.unit
 def test_load_spark_config_raises_yaml_error():
     """Tests loading the Spark configuration with a YAML error
-    
+
     Given:
         - A mocked Spark config with a YAML error
-        
+
     When:
         - load_spark_config() is called
-        
+
     Then:
         - An Exception is raised"""
     with patch("builtins.open", mock_open(read_data="fake_yaml_content")):
@@ -86,13 +86,13 @@ def test_load_spark_config_raises_yaml_error():
 @pytest.mark.unit
 def test_load_spark_config_file_not_found():
     """Tests loading the Spark configuration with the file not found
-    
+
     Given:
         - A mocked Spark config with the file not found
-        
+
     When:
         - load_spark_config() is called
-        
+
     Then:
         - An Exception is raised"""
     with patch("builtins.open", side_effect=FileNotFoundError("File not found")):
@@ -103,13 +103,13 @@ def test_load_spark_config_file_not_found():
 @pytest.mark.unit
 def test_load_spark_config_success():
     """Tests loading the Spark configuration
-    
+
     Given:
         - A mocked Spark config
-        
+
     When:
         - load_spark_config() is called
-        
+
     Then:
         - The expected Spark configuration fields are returned"""
     mock_spark_config = {"spark": {"app_name": "test-app", "master": "local[*]"}}


### PR DESCRIPTION
### Summary
Converts a Pandas DataFrame of the market data into a Spark DataFrame.
### Changes
* Implemented pandas_into_spark_df function to convert Pandas DataFrame into Spark DataFrame
* Added data validation if the Pandas DataFrame is None or empty
### Test Plan
* Setup two fixtures for unit tests
* Wrote 4 unit tests and 4 integration tests
### Evidence
====== 49 passed in 271.75s (0:04:31) ======
### Additional Notes
* https://spark.apache.org/docs/latest/api/python/getting_started/testing_pyspark.html
* https://spark.apache.org/docs/latest/api/python/getting_started/quickstart_df.html
* https://saturncloud.io/blog/how-to-convert-pandas-dataframe-to-spark-dataframe/#why-convert-a-pandas-dataframe-to-a-spark-dataframe