### PR TITLE
[Glue Workflow] Setup Glue Crawlers

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,11 +1,18 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { S3BucketStack } from '../lib/s3-bucket-stack';
+import { GlueWorkflowStack } from '../lib/glue-workflow-stack';
 
 const app = new cdk.App();
 
-const s3_bucket_stack = new S3BucketStack(app, 'CdkStack', {
+const s3_bucket_stack = new S3BucketStack(app, 'S3BucketStack', {
   env: { account: '187065639894', region: 'eu-west-2'},
   stackName: 's3-bucket-stack',
   description: 'Creates the S3 Buckets'
 });
+
+const glue_workflow_stack = new GlueWorkflowStack(app, 'GlueWorkflowStack', {
+  env: { account: '187065639894', region: 'eu-west-2'},
+  stackName: 'glue-workflow-stack',
+  description: 'Creates the Glue Workflow'
+})

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,21 +1,11 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
-import { CdkStack } from '../lib/cdk-stack';
+import { S3BucketStack } from '../lib/s3-bucket-stack';
 
 const app = new cdk.App();
-new CdkStack(app, 'CdkStack', {
-  env: { account: '187065639894', region: 'eu-west-2'}
-  /* If you don't specify 'env', this stack will be environment-agnostic.
-   * Account/Region-dependent features and context lookups will not work,
-   * but a single synthesized template can be deployed anywhere. */
 
-  /* Uncomment the next line to specialize this stack for the AWS Account
-   * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
-
-  /* Uncomment the next line if you know exactly what Account and Region you
-   * want to deploy the stack to. */
-  // env: { account: '123456789012', region: 'us-east-1' },
-
-  /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+const s3_bucket_stack = new S3BucketStack(app, 'CdkStack', {
+  env: { account: '187065639894', region: 'eu-west-2'},
+  stackName: 's3-bucket-stack',
+  description: 'Creates the S3 Buckets'
 });

--- a/cdk/lib/glue-workflow-stack.ts
+++ b/cdk/lib/glue-workflow-stack.ts
@@ -1,0 +1,62 @@
+import { Stack, StackProps } from "aws-cdk-lib";
+import { ManagedPolicy, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Construct } from "constructs";
+import { CfnCrawler, CfnDatabase } from 'aws-cdk-lib/aws-glue';
+// import * as glue from 'aws-cdk-lib/aws-glue';
+
+const glue_managed_policy = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole";
+const glue_service_url = "glue.amazonaws.com"
+const raw_s3_bucket_file_path = "s3://main-raw-tick-data-bucket/"
+// s3:// is for most AWS services, s3a:// is for Hadoop/Spark
+
+export class GlueWorkflowStack extends Stack {
+
+    public readonly glueRole: Role;
+
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const glue_db = new CfnDatabase(this, 'glue-workflow-db', {
+        catalogId: "glue-workflow-db",
+        databaseInput: {
+            name: "raw-tick-data",
+            description: "Glue Database for storing raw tick data from the raw S3 bucket",
+            parameters: {
+                classification: "parquet"
+            }
+        }
+    })
+
+    const glue_crawler_role = new Role(this, "glue-crawler-role", {
+        assumedBy: new ServicePrincipal(glue_service_url),
+        roleName: "AWSGlueServiceRole-AccessS3Bucket",
+        description: "Assigns the managed policy AWSGlueServiceRole to AWS Glue Crawler so it can crawl S3 buckets",
+        managedPolicies: [
+            ManagedPolicy.fromManagedPolicyArn(
+                this,
+                "glue-service-policy",
+                glue_managed_policy
+            )
+        ]
+    })
+    this.glueRole = glue_crawler_role
+
+    const glue_crawler_s3 = new CfnCrawler(this, "glue-crawler-s3", {
+        name: "s3-parquet-crawler",
+        role: glue_crawler_role.roleName,
+        targets: {
+            s3Targets: [
+                {
+                    path: raw_s3_bucket_file_path
+                }
+            ]
+        },
+        databaseName: glue_db.databaseName,
+        schemaChangePolicy: {
+            updateBehavior: "UPDATE_IN_DATABASE",
+            deleteBehavior: "DEPRECATE_IN_DATABASE"
+        }
+    });
+
+  }
+}

--- a/cdk/lib/s3-bucket-stack.ts
+++ b/cdk/lib/s3-bucket-stack.ts
@@ -3,7 +3,7 @@ import { Construct } from 'constructs';
 import { Bucket, BlockPublicAccess, BucketEncryption } from 'aws-cdk-lib/aws-s3';
 // import * as sqs from 'aws-cdk-lib/aws-sqs';
 
-export class CdkStack extends Stack {
+export class S3BucketStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1745,9 +1745,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1851,9 +1851,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001721",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
-      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
+      "version": "1.0.30001722",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001722.tgz",
+      "integrity": "sha512-DCQHBBZtiK6JVkAGw7drvAMK0Q0POD/xZvEmDp6baiMMP6QXXk9HpD6mNYBZWhOPG6LvIDb82ITqtWjhDckHCA==",
       "dev": true,
       "funding": [
         {
@@ -2127,9 +2127,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.165",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
-      "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
+      "version": "1.5.166",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.166.tgz",
+      "integrity": "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw==",
       "dev": true,
       "license": "ISC"
     },
@@ -2275,9 +2275,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
### Summary
Setup Glue crawlers to scan data from the raw S3 bucket and update the schema on the Glue Data Catalog
### Changes
* Changed the name of the S3 buckets stack to S3BucketStack
* Added an additional stack for Glue crawlers (to be expanded into Glue ETL pipelines)